### PR TITLE
Fix: Prevent 400 error in AI checklist generation.

### DIFF
--- a/src/hooks/new-checklist/useChecklistAI.ts
+++ b/src/hooks/new-checklist/useChecklistAI.ts
@@ -26,6 +26,13 @@ export function useChecklistAI() {
       setIsGenerating(false);
       return { success: false, error: "Campos obrigatórios não preenchidos" };
     }
+
+    // Nova validação: prompt ou descrição são necessários
+    if (!prompt.trim() && (!checklistData.description || !checklistData.description.trim())) {
+      toast.error("Forneça um prompt para a IA ou uma descrição para o checklist.");
+      setIsGenerating(false);
+      return { success: false, error: "Prompt ou descrição são necessários para a geração por IA." };
+    }
     
     try {
       console.log("Iniciando geração de checklist por IA com dados:", checklistData);


### PR DESCRIPTION
I addressed a 400 Bad Request error that occurred when generating a checklist using AI if both your specific AI prompt and the general checklist description were empty.

The Supabase Edge Function `generate-checklist-v2` requires either a prompt or a description to be present. The fix involves adding frontend validation in the `useChecklistAI.ts` hook.

Changes:
- I modified `src/hooks/new-checklist/useChecklistAI.ts` to include a check that ensures either the `prompt` state or the `checklistData.description` has a non-empty value before invoking the `generate-checklist-v2` Supabase function.
- If both are empty, an error toast is displayed to you, and the API call is prevented.

This ensures that the Edge Function is only called with the necessary inputs, resolving the 400 error and improving your experience by providing immediate feedback.